### PR TITLE
Update Discord link in links.js

### DIFF
--- a/assets/links.js
+++ b/assets/links.js
@@ -37,7 +37,7 @@ export default [
   {
     title: "Discord",
     path: "/discord",
-    target: "https://discord.gg/EnqmrU9",
+    target: "https://discord.gg/CwNUGu5",
   },
   {
     title: "Telegram",


### PR DESCRIPTION
Replaces expired Discord invite URL with a new link