### PR TITLE
remove generated _redirects file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Generated files
+public/_redirects
+
 # Nuxt dev/build outputs
 .output
 .data


### PR DESCRIPTION
probably added to version control by mistake
rebuilding site locally keeps modifying it, making local copy dirty