### PR TITLE
Remove 'Stammtisch Pad (BETA)' link

### DIFF
--- a/assets/links.js
+++ b/assets/links.js
@@ -10,11 +10,6 @@ export default [
     target: "https://funprogramming.org/pad/p/ccs",
   },
   {
-    title: "Stammtisch Pad (BETA)",
-    path: "/ccs2",
-    target: "https://cloud.creativecode.berlin/s/ccs",
-  },
-  {
     title: "Stammtisch Archive",
     path: "/archive",
     target: "https://creativecodeberlin.github.io/Stammtisch/",


### PR DESCRIPTION
Removed the 'Stammtisch Pad (BETA)' link from the list.